### PR TITLE
Slightly improve compilation times and general improvements

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule StructAccess.MixProject do
   def project do
     [
       app: :struct_access,
-      version: "1.0.0",
-      elixir: "~> 1.6",
+      version: "1.1.0",
+      elixir: "~> 1.7",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
Slightly improve compilation time and decrease the amount of code
present in modules which use StructAccess by calling out to functions
defined in StructAccess.

No longer implement the `Access.get/2` callback as this was removed as a
requirement in Elixir 1.7.0.

Make the StructAccess `Access` callback implementations overridable.

Bump the required Elixir version to "~> 1.7"

Bump the version to 1.1.0